### PR TITLE
Add support for dep locking via rebar_lock_deps_plugin

### DIFF
--- a/priv/templates/concrete_project.template
+++ b/priv/templates/concrete_project.template
@@ -3,6 +3,7 @@
   {copyright_year, "2013"},
   {author_name, "First Last"},
   {author_email,"you@example.net"},
+  {is_active, false},
   {description, "Fill in description of project here."}
 ]}.
 {dir, "src"}.

--- a/priv/templates/concrete_project_concrete.mk
+++ b/priv/templates/concrete_project_concrete.mk
@@ -25,6 +25,16 @@ ifeq ($(REBAR),)
 REBAR = $(CURDIR)/rebar
 endif
 
+# If we have a rebar.config.lock file, use it!
+ifeq ($(wildcard rebar.config.lock),rebar.config.lock)
+REBAR_CONFIG = rebar.config.lock
+else
+REBAR_CONFIG = rebar.config
+endif
+
+# This is the variable to use to respect the lock file
+REBARC = $(REBAR) -C $(REBAR_CONFIG)
+
 # For use on Travis CI, skip dialyzer for R14 and R15. Newer versions
 # have a faster dialyzer that is less likely to cause a build timeout.
 DIALYZER = dialyzer
@@ -74,6 +84,8 @@ ERLANG_DIALYZER_APPS = asn1 \
                        tools \
                        xmerl
 
+PROJ = $(notdir $(CURDIR))
+
 all: all_but_dialyzer dialyzer
 
 all_but_dialyzer: .concrete/DEV_MODE compile eunit $(ALL_HOOK)
@@ -90,26 +102,27 @@ get-rebar: $(REBAR)
 
 # Clean ebin and .eunit of this project
 clean:
-	@$(REBAR) clean skip_deps=true
+	@$(REBARC) clean skip_deps=true
 
 # Clean this project and all deps
+# Newer rebar requires -r to recursively clean
 allclean:
-	@$(REBAR) clean
+	@($(REBARC) --help 2>&1|grep -q recursive && $(REBARC) -r clean) || $(REBARC) clean
 
 compile: $(DEPS)
-	@$(REBAR) compile
+	@$(REBARC) compile
 
 $(DEPS):
-	@$(REBAR) get-deps
+	@$(REBARC) get-deps
 
 # Full clean and removal of all deps. Remove deps first to avoid
 # wasted effort of cleaning deps before nuking them.
 distclean:
 	@rm -rf deps $(DEPS_PLT)
-	@$(REBAR) clean
+	@$(REBARC) clean
 
 eunit:
-	@$(REBAR) skip_deps=true eunit
+	@$(REBARC) skip_deps=true eunit
 
 test: eunit
 
@@ -158,7 +171,7 @@ rel: relclean all_but_dialyzer $(RELX)
 	@$(RELX) -c $(RELX_CONFIG) -o $(RELX_OUTPUT_DIR) $(RELX_OPTS)
 
 devrel: rel
-devrel: lib_dir=$(wildcard $(RELX_OUTPUT_DIR)/lib/delivery-* )
+devrel: lib_dir=$(wildcard $(RELX_OUTPUT_DIR)/lib/$(PROJ)-* )
 devrel:
 	@/bin/echo -n Symlinking deps and apps into release
 	@rm -rf $(lib_dir); mkdir -p $(lib_dir)
@@ -168,6 +181,28 @@ devrel:
 
 relclean:
 	rm -rf $(RELX_OUTPUT_DIR)
+
+## Release prep and dep locking. These recipes use $(REBAR), not
+## $(REBARC) in order to NOT use the lock file since they are
+## concerned with the task of updating the lock file.
+BUMP ?= patch
+prepare_release: distclean unlocked_deps unlocked_compile update_locked_config rel
+	@echo 'release prepared, bumping version'
+	@$(REBAR) bump-rel-version version=$(BUMP)
+
+unlocked_deps:
+	@echo 'Fetching deps as: rebar -C rebar.config'
+	@$(REBAR) -C rebar.config get-deps
+
+# When running the prepare_release target, we have to ensure that a
+# compile occurs using the unlocked rebar.config. If a dependency has
+# been removed, then using the locked version that contains the stale
+# dep will cause a compile error.
+unlocked_compile:
+	@$(REBAR) -C rebar.config compile
+
+update_locked_config:
+	@$(REBAR) lock-deps skip_deps=true
 
 
 .PHONY: all all_but_dialyzer compile eunit test dialyzer clean allclean relclean distclean doc tags get-rebar rel devrel

--- a/priv/templates/concrete_project_rebar.config
+++ b/priv/templates/concrete_project_rebar.config
@@ -16,6 +16,12 @@
 %%   {proper, ".*", {git, "git://github.com/manopapad/proper.git", "master"}}
 %%  ]}.
 
+%% Set this to true if you will build OTP releases of this project via
+%% `make rel` and want to include the rebar_lock_deps_plugin. You can
+%% also specify `{branch, Branch}' or `{tag, Tag}' to use a specific
+%% build of the plugin.
+{use_lock_deps, {{is_active}} }.
+
 %% Use edown to render a markdown version of edoc. The generated
 %% markdown can be checked in and will be browsable on github. The
 %% default is to add edown as a dev only dependency and to enable

--- a/priv/templates/concrete_project_rebar.config.script
+++ b/priv/templates/concrete_project_rebar.config.script
@@ -6,7 +6,7 @@
 %%
 %% YOU SHOULDN'T NEED TO EDIT THIS FILE
 %%
-{concrete_rebar_script_version, 1}.
+{concrete_rebar_script_version, 2}.
 
 %% We need the following helper function to merge dev only options
 %% into the values provided by rebar.config.
@@ -15,7 +15,9 @@
 %% in proplist `C'. Don't duplicate items. New Items are added to the
 %% front of existing items. It is an error if the value at `Key' is
 %% not a list in `C'.
-MergeConfig = fun({Key, ToAdd}, C) ->
+MergeConfig = fun(skip, C) ->
+                      C;
+                 ({Key, ToAdd}, C) ->
                       case lists:keyfind(Key, 1, C) of
                           false ->
                               lists:keystore(Key, 1, C, {Key, ToAdd});
@@ -24,7 +26,7 @@ MergeConfig = fun({Key, ToAdd}, C) ->
                               ToAdd1 = [ I || I <- ToAdd, not lists:member(I, List) ],
                               lists:keystore(Key, 1, C, {Key, ToAdd1 ++ List })
                       end
-              end.
+              end,
 
 %% -- Add development only options if we are a top-level build  --
 %%
@@ -35,52 +37,57 @@ MergeConfig = fun({Key, ToAdd}, C) ->
 
 %% This macro can be used to conditionally enable code (e.g. tests)
 %% that depend on development only dependencies.
-ErlOpts = {erl_opts, [
-    {d, 'DEV_ONLY'}
-]},
+ErlOpts = {erl_opts, [{d, 'DEV_ONLY'}]},
 
 %% Development only dependencies can be specified in the main
 %% rebar.config. This file should not need to be edited directly.
 DevOnlyDeps = case lists:keyfind(dev_only_deps, 1, CONFIG) of
                   false ->
-                      [];
+                      skip;
                   {dev_only_deps, DOD} ->
-                      DOD
+                      {deps, DOD}
               end,
 
-EdownMe =
-fun(C) ->
-        %% Unless rebar.config contains `{use_edown, false}', we'll
-        %% wire it up. However, we'll only add the required edoc_opts
-        %% if none have been provided.
-        case proplists:get_value(use_edown, C) of
-            false ->
-                C;
-            _ ->
-                %% only add edoc_opts if none are present
-                C1 = case lists:keymember(edoc_opts, 1, C) of
-                         true ->
-                             C;
-                         false ->
-                             MergeConfig({edoc_opts, [{doclet, edown_doclet}]}, C)
-                     end,
-                MergeConfig({deps,
-                             [{edown, ".*",
-                               {git, "git://github.com/seth/edown.git",
-                                {branch, "master"}}}]},
-                            C1)
-        end
-end,
+EDown = case proplists:get_value(use_edown, CONFIG) of
+               false ->
+                   skip;
+               _ ->
+                DocOpts = case lists:keymember(edoc_opts, 1, CONFIG) of
+                              true ->
+                                  skip;
+                              false ->
+                                  {edoc_opts, [{doclet, edown_doclet}]}
+                          end,
+                [DocOpts,
+                 {deps,
+                  [{edown, ".*",
+                    {git, "git://github.com/seth/edown.git",
+                     {branch, "master"}}}]}]
+           end,
 
-Deps = {deps, DevOnlyDeps},
+LockDeps = case proplists:get_value(use_lock_deps, CONFIG) of
+               false ->
+                   skip;
+               V ->
+                   Tag = case V of
+                             {_, _} = T -> T;
+                             _ -> {branch, "master"}
+                         end,
+                   [{deps,
+                     [{rebar_lock_deps_plugin, ".*",
+                       {git, "git://github.com/seth/rebar_lock_deps_plugin.git",
+                        Tag}}]},
+                    {plugins, [rebar_lock_deps_plugin]}]
+           end,
 
 ConfigPath = filename:dirname(SCRIPT),
 DevMarker = filename:join([ConfigPath, ".concrete/DEV_MODE"]),
 
 case filelib:is_file(DevMarker) of
     true ->
+        ToMerge = lists:flatten([DevOnlyDeps, LockDeps, EDown, ErlOpts]),
         lists:foldl(fun(I, C) -> MergeConfig(I, C) end,
-                    EdownMe(CONFIG), [Deps, ErlOpts]);
+                    CONFIG, ToMerge);
     false ->
         %% If the .concrete/ marker is not present, this script simply
         %% returns the config specified in rebar.config. This will be

--- a/src/concrete.erl
+++ b/src/concrete.erl
@@ -46,17 +46,18 @@ concrete_init(Dir) ->
     io:format("Creating the ~s project with concrete\n\n", [Dir]),
     Name = strip(Dir),
     ActiveApp = yes_no(io:get_line("Would you like an active application? (y/n): ")),
-    render_project(Name),
-    render_active(Name,ActiveApp),
+    render_project(Name, ActiveApp),
+    render_active(Name, ActiveApp),
     io:format("Now try: cd ~s; make\n", [Dir]),
     ok.
 
-render_project(Name) ->
+render_project(Name, ActiveApp) ->
     Cmd = [rebar_exe(),
            "create",
            "template_dir=" ++ template_dir(),
            "template=concrete_project",
-           "name=" ++ Name],
+           "name=" ++ Name,
+           "is_active=" ++ atom_to_list(ActiveApp)],
     handle_cmd(run_cmd(Cmd, Name)).
     
 render_active(Name, true) ->


### PR DESCRIPTION
- If a rebar.config.lock file is present, it will be used with the
  exception of the prepare_release target and its friends.
- The allclean target is enhanced to detect with the rebar in play
  requires a -r flag or not to clean all deps.
- Fix bad copy/paste hard code in newly added devrel target
- Add prepare_release target with relx integration
- Generated rebar.config now includes {use_lock_deps, X}. X defaults to
  false for non-active projects and true otherwise. It is also possible
  to specify a branch or tag of the rebar_lock_deps_plugin here.
- Refactor cleanup of generated rebar.config.script. Incremented version
  to 2. Adds support for optionally including rebar_lock_deps_plugin.

Also cleanup of shell target and additional of devrel target.
