### PR TITLE
Remove eunit from list of apps to include in base ~/.dialyzer_plt

### DIFF
--- a/priv/templates/concrete_project_concrete.mk
+++ b/priv/templates/concrete_project_concrete.mk
@@ -73,7 +73,6 @@ ERLANG_DIALYZER_APPS = asn1 \
                        crypto \
                        edoc \
                        erts \
-                       eunit \
                        inets \
                        kernel \
                        mnesia \


### PR DESCRIPTION
In R17 eunit triggers a warning when included in a PLT. This warning can
be ignored with a dialyzer.mitigate file, but since coding against the
eunit API is rare, it seems better to remove it from the default base
PLT and avoid littering all projects with the mitigation file.

ping @jwilberding 
