### PR TITLE
print-newline-when-building-releases

### DIFF
--- a/priv/templates/concrete_project_concrete.mk
+++ b/priv/templates/concrete_project_concrete.mk
@@ -172,7 +172,7 @@ rel: relclean all_but_dialyzer $(RELX)
 devrel: rel
 devrel: lib_dir=$(wildcard $(RELX_OUTPUT_DIR)/lib/$(PROJ)-* )
 devrel:
-	@/bin/echo -n Symlinking deps and apps into release
+	@/bin/echo Symlinking deps and apps into release
 	@rm -rf $(lib_dir); mkdir -p $(lib_dir)
 	@ln -sf `pwd`/ebin $(lib_dir)
 	@ln -sf `pwd`/priv $(lib_dir)


### PR DESCRIPTION
- Print a newline when emitting a status message during development
  release builds [obvious fix].

This changes this output:

```
jkakar@rex:~/src/github.com/heroku/keg$ make devrel
rm -rf _rel
==> edown (compile)
==> rebar_lock_deps_plugin (compile)
---- 8< snip 8< ---- 8< snip 8< ---- 8< snip 8< ---- 8< snip 8< ----
===> release successfully created!
Symlinking deps and apps into releasejkakar@rex:~/src/github.com/heroku/keg$
```

to this:

```
jkakar@rex:~/src/github.com/heroku/keg$ make devrel
rm -rf _rel
==> edown (compile)
==> rebar_lock_deps_plugin (compile)
---- 8< snip 8< ---- 8< snip 8< ---- 8< snip 8< ---- 8< snip 8< ----
===> release successfully created!
Symlinking deps and apps into release
jkakar@rex:~/src/github.com/heroku/keg$
```
