### PR TITLE
Merge concrete's stuff into rebar config at the end.

### DIFF
--- a/priv/templates/concrete_project_rebar.config.script
+++ b/priv/templates/concrete_project_rebar.config.script
@@ -6,7 +6,7 @@
 %%
 %% YOU SHOULDN'T NEED TO EDIT THIS FILE
 %%
-{concrete_rebar_script_version, 2}.
+{concrete_rebar_script_version, 3}.
 
 %% We need the following helper function to merge dev only options
 %% into the values provided by rebar.config.
@@ -24,7 +24,7 @@ MergeConfig = fun(skip, C) ->
                           {Key, List} when is_list(List) ->
                               %% remove items in ToAdd already in List
                               ToAdd1 = [ I || I <- ToAdd, not lists:member(I, List) ],
-                              lists:keystore(Key, 1, C, {Key, ToAdd1 ++ List })
+                              lists:keystore(Key, 1, C, {Key, List ++ ToAdd1 })
                       end
               end,
 


### PR DESCRIPTION
Fixes issues with things like adding the lager_transform to rebar.config
## Before

```
➜ notifier git:(jd/ct) ✗ rebar compile
WARN:  Missing plugins: [rebar_lock_deps_plugin]
WARN:  Missing plugins: [rebar_lock_deps_plugin]
==> edown (compile)
WARN:  Missing plugins: [rebar_lock_deps_plugin]
==> rebar_lock_deps_plugin (compile)
Compiling /Users/joe/dev/opscode/notifier/deps/rebar_lock_deps_plugin/src/rldp_util.erl failed:
/Users/joe/dev/opscode/notifier/deps/rebar_lock_deps_plugin/src/rldp_util.erl:none: undefined parse transform 'lager_transform'
ERROR: compile failed while processing /Users/joe/dev/opscode/notifier/deps/rebar_lock_deps_plugin: rebar_abort
```
## After

```
➜ notifier git:(jd/ct) ✗ rebar compile
==> goldrush (compile)
==> lager (compile)
==> rabbit_common (compile)
==> amqp_client (compile)
==> ej (compile)
==> envy (compile)
==> eper (compile)
==> ibrowse (compile)
==> jiffy (compile)
==> meck (compile)
==> rebar_lock_deps_plugin (compile)
==> edown (compile)
==> notifier (compile)
➜ notifier git:(jd/ct) ✗ 
```

It's great!
