### PR TITLE
made $PROJ overridable

### DIFF
--- a/priv/templates/concrete_project_concrete.mk
+++ b/priv/templates/concrete_project_concrete.mk
@@ -83,7 +83,7 @@ ERLANG_DIALYZER_APPS ?= asn1 \
                         tools \
                         xmerl
 
-PROJ = $(notdir $(CURDIR))
+PROJ ?= $(notdir $(CURDIR))
 
 # Let's compute $(BASE_PLT_ID) that identifies the base PLT to use for this project
 # and depends on your `$(ERLANG_DIALYZER_APPS)' list and your erlang version


### PR DESCRIPTION
If you check out a concrete project into a directory not named the same as the erlang application, devrel target will not properly link, since it uses the root directory name as the erlang application name.

Slapping this `?` in there allows $PROJ to be overridden from `custom.mk` in the rare cases that this is the default behavior.

This is of particular concern in Chef's dev-vm workflow.