### PR TITLE
Use TRAVIS_OTP_RELEASE for accurate full version

### DIFF
--- a/priv/templates/concrete_project_concrete.mk
+++ b/priv/templates/concrete_project_concrete.mk
@@ -104,7 +104,7 @@ ifeq ($(TRAVIS),true)
 ## reported by erlang:system_info(otp_release)
 ## s3cmd put --acl-public --guess-mime-type <FILENAME> s3://concrete-plts
 
-BASE_PLT := travis-erlang-$(ERLANG_VERSION).plt
+BASE_PLT := travis-erlang-$(TRAVIS_OTP_RELEASE).plt
 BASE_PLT_URL := http://s3.amazonaws.com/concrete-plts/$(BASE_PLT)
 else
 BASE_PLT := ~/.concrete_dialyzer_plt_$(BASE_PLT_ID)_$(ERLANG_VERSION).plt


### PR DESCRIPTION
 Instead of the calculated ERLANG_VERSION, use TRAVIS_OTP_RELEASE when on travis - this is a more complete version since the version numbering scheme change (eg 17.x vs 17). 

ping @joedevivo 