### PR TITLE
Use the canonical repo for edown

### DIFF
--- a/priv/templates/concrete_project_rebar.config.script
+++ b/priv/templates/concrete_project_rebar.config.script
@@ -61,7 +61,7 @@ EDown = case proplists:get_value(use_edown, CONFIG) of
                 [DocOpts,
                  {deps,
                   [{edown, ".*",
-                    {git, "git://github.com/seth/edown.git",
+                    {git, "git://github.com/uwiger/edown.git",
                      {branch, "master"}}}]}]
            end,
 


### PR DESCRIPTION
Patches that motivated the use of seth/edown have been merged upstream.