### PR TITLE
Using the canonical edown repo

### DIFF
--- a/priv/templates/concrete_project_rebar.config.script
+++ b/priv/templates/concrete_project_rebar.config.script
@@ -61,7 +61,7 @@ EDown = case proplists:get_value(use_edown, CONFIG) of
                 [DocOpts,
                  {deps,
                   [{edown, ".*",
-                    {git, "git://github.com/seth/edown.git",
+                    {git, "git://github.com/uwiger/edown.git",
                      {branch, "master"}}}]}]
            end,
 


### PR DESCRIPTION
Mostly to be able to use Concrete with OTP 18.x
(see https://github.com/uwiger/edown/commit/b7c8eb0ac1859f8fce11cbfe3526f5ec83194776)